### PR TITLE
Fix refresh bug in managed auth demo app

### DIFF
--- a/reading-list-app/reading-list-front-end-with-managed-auth/src/api/retry.ts
+++ b/reading-list-app/reading-list-front-end-with-managed-auth/src/api/retry.ts
@@ -26,11 +26,9 @@ export const performRequestWithRetry = async (url: string, options: AxiosRequest
   } catch (error) {
     if (error.response && error.response.status === 401) {
       // Access token may be expired. Try to refresh the tokens.
+      console.log('Access token may be expired. Trying to refresh the tokens.');
       try {
         await axios.post('/auth/refresh');
-        // Token refresh successful. Retry the API call.
-        const retryResponse = await axios(url, options);
-        return retryResponse;
       } catch (refreshError) {
         if (refreshError.response && refreshError.response.status === 401) {
           // Session has expired (i.e., Refresh token has also expired).
@@ -43,6 +41,10 @@ export const performRequestWithRetry = async (url: string, options: AxiosRequest
           throw error;
         }
       }
+      // Token refresh successful. Retry the API call.
+      console.log('Token refresh successful. Retrying the API call.');
+      const retryResponse = await axios(url, options);
+      return retryResponse;
     } else {
       throw error;
     }

--- a/reading-list-app/reading-list-front-end-with-managed-auth/src/api/retry.ts
+++ b/reading-list-app/reading-list-front-end-with-managed-auth/src/api/retry.ts
@@ -35,6 +35,7 @@ export const performRequestWithRetry = async (url: string, options: AxiosRequest
           // Redirect to the login page
           console.log('Failed to refresh token. Status: ' + refreshError.response.status);
           window.location.href = '/auth/login';
+          return;
         } else {
           // We can't refresh the token due to a server error.
           // Hence just throw the original 401 error from the API.


### PR DESCRIPTION
## Purpose
$subject.

If the refresh was successful but the API called failed again with a 401, this bug caused a prompt to login. This fixes the bug